### PR TITLE
Return multiple queries in single write

### DIFF
--- a/pyvisa-sim/devices.py
+++ b/pyvisa-sim/devices.py
@@ -245,7 +245,10 @@ class Device(Component):
 
                 if response is not NoResponse:
                     self._output_buffer.extend(response)
-                    self._output_buffer.extend(eom)
+                    if query == queries[-1]:
+                        self._output_buffer.extend(eom)
+                    else:
+                        self._output_buffer.extend(self.delimiter)
 
         finally:
             self._input_buffer = bytearray()


### PR DESCRIPTION
modified write() definition to respond to multiple queries

If "?FREQ" returns "100.0" and "?AMP" returns "1.0"
Functionality before: 
"?FREQ;?AMP" returns "1"
Functionality after:
"?FREQ;?AMP" returns "1;2"

Chaining queries together may not work like this on all devices, so this may or may not be a good change for general purpose.